### PR TITLE
Volume too low fix

### DIFF
--- a/Pitch Perfect/RecordSoundsViewController.swift
+++ b/Pitch Perfect/RecordSoundsViewController.swift
@@ -49,7 +49,9 @@ class RecordSoundsViewController: UIViewController, AVAudioRecorderDelegate {
         let filePath = NSURL.fileURLWithPathComponents(pathArray)
         
         var session = AVAudioSession.sharedInstance()
-        session.setCategory(AVAudioSessionCategoryPlayAndRecord, error: nil)
+        //session.setCategory(AVAudioSessionCategoryPlayAndRecord, error: nil)
+        session.setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: .DefaultToSpeaker)
+        // adding withOptions: .DefaultToSpeaker fixes your problem with the volume being too quiet.
         
         audioRecorder = AVAudioRecorder(URL: filePath, settings: nil, error: nil)
         


### PR DESCRIPTION
As you mentioned in your readme file that the volume of the recording is SUPER QUIET, the fix is to add the attribute withOptions: .DefaultToSpeaker when setting the AVAudioSession Category.
